### PR TITLE
properly handle subscribed topics with + wildcard

### DIFF
--- a/src/main/java/com/adr/helloiot/ApplicationTopicsManager.java
+++ b/src/main/java/com/adr/helloiot/ApplicationTopicsManager.java
@@ -146,7 +146,7 @@ public final class ApplicationTopicsManager implements TopicManager {
     }
 
     private void distributeMessage(EventMessage message) {
-        for (var entry: subscriptions.entrySet()) {
+        for (Map.Entry<String, List<TopicSubscription>> entry: subscriptions.entrySet()) {
             if (MqttTopic.isMatched(entry.getKey(), message.getTopic())) {
                 List<TopicSubscription> subs = entry.getValue();
                 if (subs != null) {

--- a/src/main/java/com/adr/helloiot/ApplicationTopicsManager.java
+++ b/src/main/java/com/adr/helloiot/ApplicationTopicsManager.java
@@ -34,6 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import com.adr.helloiotlib.app.TopicManager;
 import com.adr.helloiotlib.format.MiniVar;
+import org.eclipse.paho.client.mqttv3.MqttTopic;
 
 /**
  *
@@ -145,26 +146,14 @@ public final class ApplicationTopicsManager implements TopicManager {
     }
 
     private void distributeMessage(EventMessage message) {
-        distributeWilcardMessage(message.getTopic(), message);
-        distributeRecursiveMessage(message.getTopic().length() - 1, message);
-    }
-
-    private void distributeRecursiveMessage(int starting, EventMessage message) {
-        String topic = message.getTopic();
-        int i = topic.lastIndexOf('/', starting);
-        if (i < 0) {
-            distributeWilcardMessage("#", message);
-        } else {
-            distributeWilcardMessage(topic.substring(0, i) + "/#", message);
-            distributeRecursiveMessage(i - 1, message);
-        }
-    }
-
-    private void distributeWilcardMessage(String subscriptiontopic, EventMessage message) {
-        List<TopicSubscription> subs = subscriptions.get(subscriptiontopic);
-        if (subs != null) {
-            for (TopicSubscription s : subs) {
-                s.consume(message);
+        for (var entry: subscriptions.entrySet()) {
+            if (MqttTopic.isMatched(entry.getKey(), message.getTopic())) {
+                List<TopicSubscription> subs = entry.getValue();
+                if (subs != null) {
+                    for (TopicSubscription s : subs) {
+                        s.consume(message);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Currently subscribe panels can handle wildcard topics containing # properly, but not topics containing +. This pull request contains a fix that allows a subscribe panel with + as part of the topic name to correctly receive incoming messages by employing a topic matching function available in Paho's MQTT implementation.